### PR TITLE
chore: update codeql queries

### DIFF
--- a/chapter-03/integer-overflow-example/IntegerOverflowOriginal.ql
+++ b/chapter-03/integer-overflow-example/IntegerOverflowOriginal.ql
@@ -23,11 +23,10 @@ module IntegerOverflowConfig implements DataFlow::ConfigSig {
     }
 
     predicate isSink(DataFlow::Node sink) {
-        exists(Expr e, ExprCall ec, MacroInvocation mi | e = sink.asExpr() |
-            ec = mi.getExpr() and
-            mi.getMacroName() = "REALLOC" and
-            e = ec.getAnArgument() and
-            e.getUnspecifiedType() instanceof IntegralType
+        exists(Expr e, HeuristicAllocationExpr alloc | e = sink.asConvertedExpr() |
+            e = alloc.getAChild() and
+            e.getUnspecifiedType() instanceof IntegralType and
+            not e instanceof Conversion
         )
     }
 }


### PR DESCRIPTION
This updates the CodeQL queries to use the new dataflow/taint tracking API as the old API is being deprecated. CodeQL CLI v2.20.2, released 2 hours ago, finally adds the new API for JavaScript, so this is timely.