### PR TITLE
chapter-03: Fix indentation in cve-2021-46143-variant-1.yml

### DIFF
--- a/chapter-03/cve-2021-46143/cve-2021-46143-variant-1.yml
+++ b/chapter-03/cve-2021-46143/cve-2021-46143-variant-1.yml
@@ -4,6 +4,6 @@ rules:
     - pattern-either:
       - pattern: REALLOC(parser, $POINTER, $SIZE * $CONSTANT);
       - pattern: REALLOC(parser, $POINTER, $SIZE *= $CONSTANT);
-	message: Detected variant of CVE-2021-46143.
-	languages: [c]
-	severity: ERROR
+  message: Detected variant of CVE-2021-46143.
+  languages: [c]
+  severity: ERROR


### PR DESCRIPTION
## Problem

_What problem are you trying to solve? What issue does this close?_

Running `semgrep` with `chapter-03/cve-2021-46143/cve-2021-46143-variant-1.yml` fails because it has tab character.

Closes [insert issue #]

## Solution

_How did you solve the problem?_

replace tab with spaces

